### PR TITLE
word errors fixed

### DIFF
--- a/docs/swiper.jade
+++ b/docs/swiper.jade
@@ -1315,7 +1315,7 @@ block content
       pre
         code
           | &lt;div class="page-content"&gt;
-          |   &lt;div class="slider-custom"&gt;
+          |   &lt;div class="swiper-custom"&gt;
           |     &lt;div class="swiper-container"&gt;
           |       &lt;div class="swiper-pagination"&gt;&lt;/div&gt;
           |       &lt;div class="swiper-wrapper"&gt;
@@ -1328,8 +1328,8 @@ block content
           |         &lt;div class="swiper-slide"&gt;&lt;span&gt;Slide 7&lt;/span&gt;&lt;/div&gt;
           |       &lt;/div&gt;
           |     &lt;/div&gt;
-          |     &lt;div class="slider-button-prev"&gt;&lt;/div&gt;
-          |     &lt;div class="slider-button-next"&gt;&lt;/div&gt;
+          |     &lt;div class="swiper-button-prev"&gt;&lt;/div&gt;
+          |     &lt;div class="swiper-button-next"&gt;&lt;/div&gt;
           |   &lt;/div&gt;
           | &lt;/div&gt;
       pre


### PR DESCRIPTION
Hi there, 

There exists some word errors on Line 1318, Line 1331 and Line 1332, the `slider-`s should be `swiper-`s.

So if i copy directly from page, it doesn't work as expected